### PR TITLE
added initial version of the shex.shexc generator

### DIFF
--- a/ns/context.jsonld
+++ b/ns/context.jsonld
@@ -35,28 +35,12 @@
     "TripleConstraint": "shex:TripleConstraint",
     "TripleExpression": "shex:TripleExpression",
     "Wildcard": "shex:Wildcard",
-    "annotation": {
-      "@id": "shex:annotation",
+    "object": {
+      "@id": "shex:object",
       "@type": "@id"
     },
-    "closed": {
-      "@id": "shex:closed",
-      "@type": "xsd:boolean"
-    },
-    "code": {
-      "@id": "shex:code",
-      "@language": null
-    },
-    "datatype": {
-      "@id": "shex:datatype",
-      "@type": "@id"
-    },
-    "exclusion": {
-      "@id": "shex:exclusion",
-      "@type": "@id"
-    },
-    "expression": {
-      "@id": "shex:expression",
+    "predicate": {
+      "@id": "shex:predicate",
       "@type": "@id"
     },
     "expressions": {
@@ -64,24 +48,34 @@
       "@type": "@id",
       "@container": "@list"
     },
-    "extra": {
-      "@id": "shex:extra",
+    "annotation": {
+      "@id": "shex:annotation",
       "@type": "@id"
+    },
+    "max": {
+      "@id": "shex:max",
+      "@type": "xsd:integer"
+    },
+    "min": {
+      "@id": "shex:min",
+      "@type": "xsd:integer"
+    },
+    "semActs": {
+      "@id": "shex:semActs",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "datatype": {
+      "@id": "shex:datatype",
+      "@type": "xsd:Datatype"
     },
     "fractiondigits": {
       "@id": "shex:fractiondigits",
       "@type": "xsd:integer"
     },
-    "inverse": {
-      "@id": "shex:inverse",
-      "@type": "xsd:boolean"
-    },
     "length": {
       "@id": "shex:length",
       "@type": "xsd:integer"
-    },
-    "max": {
-      "@id": "shex:max"
     },
     "maxexclusive": {
       "@id": "shex:maxexclusive",
@@ -95,78 +89,17 @@
       "@id": "shex:maxlength",
       "@type": "xsd:integer"
     },
-    "min": {
-      "@id": "shex:min",
-      "@type": "xsd:integer"
-    },
-    "minexclusive": {
-      "@id": "shex:minexclusive",
-      "@type": "xsd:integer"
-    },
-    "mininclusive": {
-      "@id": "shex:mininclusive",
-      "@type": "xsd:integer"
-    },
     "minlength": {
       "@id": "shex:minlength",
       "@type": "xsd:integer"
-    },
-    "name": {
-      "@id": "shex:name",
-      "@type": "@id"
     },
     "nodeKind": {
       "@id": "shex:nodeKind",
       "@type": "@vocab"
     },
-    "numericFacet": {
-      "@id": "shex:numericFacet"
-    },
-    "object": {
-      "@id": "shex:object",
-      "@type": "@id"
-    },
     "pattern": {
       "@id": "shex:pattern",
       "@language": null
-    },
-    "predicate": {
-      "@id": "shex:predicate",
-      "@type": "@id"
-    },
-    "semActs": {
-      "@id": "shex:semActs",
-      "@type": "@id",
-      "@container": "@list"
-    },
-    "shapes": {
-      "@id": "shex:shapes",
-      "@type": "@id"
-    },
-    "shapeExpr": {
-      "@id": "shex:shapeExpr",
-      "@type": "@id"
-    },
-    "shapeExprs": {
-      "@id": "shex:shapeExprs",
-      "@type": "@id",
-      "@container": "@list"
-    },
-    "start": {
-      "@id": "shex:start",
-      "@type": "@id"
-    },
-    "startActs": {
-      "@id": "shex:startActs",
-      "@type": "@id",
-      "@container": "@list"
-    },
-    "stem": {
-      "@id": "shex:stem",
-      "@type": "xsd:anyUri"
-    },
-    "stringFacet": {
-      "@id": "shex:stringFacet"
     },
     "totaldigits": {
       "@id": "shex:totaldigits",
@@ -177,12 +110,72 @@
       "@type": "@id",
       "@container": "@list"
     },
+    "xsFacet": {
+      "@id": "shex:xsFacet"
+    },
+    "shapes": {
+      "@id": "shex:shapes",
+      "@type": "@id"
+    },
+    "start": {
+      "@id": "shex:start",
+      "@type": "@id"
+    },
+    "startActs": {
+      "@id": "shex:startActs",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "code": {
+      "@id": "shex:code",
+      "@language": null
+    },
+    "name": {
+      "@id": "shex:name",
+      "@type": "@id"
+    },
+    "closed": {
+      "@id": "shex:closed",
+      "@type": "xsd:boolean"
+    },
+    "expression": {
+      "@id": "shex:expression",
+      "@type": "@id"
+    },
+    "extra": {
+      "@id": "shex:extra",
+      "@type": "@id"
+    },
+    "shapeExprs": {
+      "@id": "shex:shapeExprs",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "shapeExpr": {
+      "@id": "shex:shapeExpr",
+      "@type": "@id"
+    },
+    "stem": {
+      "@id": "shex:stem",
+      "@type": "xsd:anyUri"
+    },
+    "exclusion": {
+      "@id": "shex:exclusion",
+      "@type": "@id"
+    },
+    "inverse": {
+      "@id": "shex:inverse",
+      "@type": "xsd:boolean"
+    },
     "valueExpr": {
       "@id": "shex:valueExpr",
       "@type": "@id"
     },
-    "xsFacet": {
-      "@id": "shex:xsFacet"
+    "numericFacet": {
+      "@id": "shex:numericFacet"
+    },
+    "stringFacet": {
+      "@id": "shex:stringFacet"
     },
     "literal": "shex:literal",
     "nonliteral": "shex:nonliteral",
@@ -271,8 +264,8 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used in the Shape Expression Language (ShEx) [[shex]] along with the default JSON-LD Context."
     },
-    "dc:date": "2017-01-18",
-    "owl:versionInfo": "https://github.com/shexSpec/shexspec.github.io/commit/af16ff5da669b204026a80287d211f9b4ffaf2ef",
+    "dc:date": "2017-01-22",
+    "owl:versionInfo": "https://github.com/shexSpec/shexspec.github.io/commit/8699b802204fe7c964ed4dff965ceb54d3c080f3",
     "rdfs:seeAlso": [
       "https://shexspec.github.io/spec"
     ],
@@ -469,87 +462,33 @@
     ],
     "rdfs_properties": [
       {
-        "@id": "shex:annotation",
+        "@id": "shex:object",
         "@type": "rdf:Property",
         "rdfs:label": {
-          "en": "annotation"
+          "en": "object"
         },
         "rdfs:comment": {
-          "en": "Annotations on a TripleExpression."
+          "en": "The object of an Annotation."
+        },
+        "rdfs:domain": "shex:Annotation",
+        "rdfs:range": "rdfs:Resource"
+      },
+      {
+        "@id": "shex:predicate",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "predicate"
+        },
+        "rdfs:comment": {
+          "en": "The predicate of a TripleConstraint or Annotation."
         },
         "rdfs:domain": {
           "owl:unionOf": [
-            "shex:EachOf",
-            "shex:OneOf",
+            "shex:Annotation",
             "shex:TripleConstraint"
           ]
         },
-        "rdfs:range": "shex:Annotation"
-      },
-      {
-        "@id": "shex:closed",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "closed"
-        },
-        "rdfs:comment": {
-          "en": "Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints."
-        },
-        "rdfs:domain": "shex:Shape",
-        "rdfs:range": "xsd:boolean"
-      },
-      {
-        "@id": "shex:code",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "code"
-        },
-        "rdfs:comment": {
-          "en": "Code executed by Semantic Action."
-        },
-        "rdfs:domain": "shex:SemAct",
-        "rdfs:range": "xsd:string"
-      },
-      {
-        "@id": "shex:datatype",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "datatype"
-        },
-        "rdfs:comment": {
-          "en": "A datatype constraint."
-        },
-        "rdfs:domain": "shex:NodeConstraint",
-        "rdfs:range": "rdfs:Datatype"
-      },
-      {
-        "@id": "shex:exclusion",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "exclusion"
-        },
-        "rdfs:comment": {
-          "en": "Values that are excluded from value matching."
-        },
-        "rdfs:domain": "shex:StemRange",
-        "rdfs:range": {
-          "owl:unionOf": [
-            "rdfs:Resource",
-            "shex:Stem"
-          ]
-        }
-      },
-      {
-        "@id": "shex:expression",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "expression"
-        },
-        "rdfs:comment": {
-          "en": "Expression associated with the TripleExpression."
-        },
-        "rdfs:domain": "shex:Shape",
-        "rdfs:range": "shex:TripleExpression"
+        "rdfs:range": "rdfs:Resource"
       },
       {
         "@id": "shex:expressions",
@@ -569,54 +508,22 @@
         "rdfs:range": "shex:TripleExpression"
       },
       {
-        "@id": "shex:extra",
+        "@id": "shex:annotation",
         "@type": "rdf:Property",
         "rdfs:label": {
-          "en": "extra"
+          "en": "annotation"
         },
         "rdfs:comment": {
-          "en": "Properties which may have extra values beyond those matched through a constraint."
+          "en": "Annotations on a TripleExpression."
         },
-        "rdfs:domain": "shex:Shape",
-        "rdfs:range": "rdfs:Resource"
-      },
-      {
-        "@id": "shex:fractiondigits",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "fraction digits"
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "shex:EachOf",
+            "shex:OneOf",
+            "shex:TripleConstraint"
+          ]
         },
-        "rdfs:comment": {
-          "en": "for \"fractiondigits\" constraints, v is less than or equals the number of digits to the right of the decimal place in the XML Schema canonical form[xmlschema-2] of the value of n, ignoring trailing zeros."
-        },
-        "rdfs:subPropertyOf": "shex:numericFacet",
-        "rdfs:domain": "shex:NodeConstraint",
-        "rdfs:range": "xsd:integer"
-      },
-      {
-        "@id": "shex:inverse",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "inverse"
-        },
-        "rdfs:comment": {
-          "en": "Constrains the subject of a triple, rather than the object."
-        },
-        "rdfs:domain": "shex:TripleConstraint",
-        "rdfs:range": "xsd:boolean"
-      },
-      {
-        "@id": "shex:length",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "length"
-        },
-        "rdfs:comment": {
-          "en": "The exact length of the value of the cell."
-        },
-        "rdfs:subPropertyOf": "shex:stringFacet",
-        "rdfs:domain": "shex:NodeConstraint",
-        "rdfs:range": "xsd:integer"
+        "rdfs:range": "shex:Annotation"
       },
       {
         "@id": "shex:max",
@@ -633,7 +540,82 @@
             "shex:OneOf",
             "shex:TripleConstraint"
           ]
-        }
+        },
+        "rdfs:range": "xsd:integer"
+      },
+      {
+        "@id": "shex:min",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "minimum cardinatliy"
+        },
+        "rdfs:comment": {
+          "en": "Minimum number of times this TripleExpression may match."
+        },
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "shex:EachOf",
+            "shex:OneOf",
+            "shex:TripleConstraint"
+          ]
+        },
+        "rdfs:range": "xsd:integer"
+      },
+      {
+        "@id": "shex:semActs",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "semantic action"
+        },
+        "rdfs:comment": {
+          "en": "Semantic Actions on this TripleExpression."
+        },
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "shex:EachOf",
+            "shex:OneOf",
+            "shex:TripleConstraint"
+          ]
+        },
+        "rdfs:range": "shex:SemAct"
+      },
+      {
+        "@id": "shex:datatype",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "datatype"
+        },
+        "rdfs:comment": {
+          "en": "A datatype constraint."
+        },
+        "rdfs:domain": "shex:NodeConstraint",
+        "rdfs:range": "xsd:Datatype"
+      },
+      {
+        "@id": "shex:fractiondigits",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "fraction digits"
+        },
+        "rdfs:comment": {
+          "en": "for \"fractiondigits\" constraints, v is less than or equals the number of digits to the right of the decimal place in the XML Schema canonical form[xmlschema-2] of the value of n, ignoring trailing zeros."
+        },
+        "rdfs:subPropertyOf": "shex:numericFacet",
+        "rdfs:domain": "shex:NodeConstraint",
+        "rdfs:range": "xsd:integer"
+      },
+      {
+        "@id": "shex:length",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "length"
+        },
+        "rdfs:comment": {
+          "en": "The exact length of the value of the cell."
+        },
+        "rdfs:subPropertyOf": "shex:stringFacet",
+        "rdfs:domain": "shex:NodeConstraint",
+        "rdfs:range": "xsd:integer"
       },
       {
         "@id": "shex:maxexclusive",
@@ -661,7 +643,7 @@
           "en": "max inclusive"
         },
         "rdfs:comment": {
-          "en": "An atomic property that contains a single number that is the maximum valid value (inclusive)."
+          "en": "An atomic property that contains a single number that is the minimum valid value (inclusive)."
         },
         "rdfs:subPropertyOf": "shex:numericFacet",
         "rdfs:domain": "shex:NodeConstraint",
@@ -687,62 +669,6 @@
         "rdfs:range": "xsd:integer"
       },
       {
-        "@id": "shex:min",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "minimum cardinatliy"
-        },
-        "rdfs:comment": {
-          "en": "Minimum number of times this TripleExpression may match."
-        },
-        "rdfs:domain": {
-          "owl:unionOf": [
-            "shex:EachOf",
-            "shex:OneOf",
-            "shex:TripleConstraint"
-          ]
-        },
-        "rdfs:range": "xsd:integer"
-      },
-      {
-        "@id": "shex:minexclusive",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "min exclusive"
-        },
-        "rdfs:comment": {
-          "en": "An atomic property that contains a single number that is the minimum valid value (exclusive)."
-        },
-        "rdfs:subPropertyOf": "shex:numericFacet",
-        "rdfs:domain": "shex:NodeConstraint",
-        "rdfs:range": {
-          "owl:unionOf": [
-            "xsd:integer",
-            "xsd:decimal",
-            "xsd:double"
-          ]
-        }
-      },
-      {
-        "@id": "shex:mininclusive",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "min inclusive"
-        },
-        "rdfs:comment": {
-          "en": "An atomic property that contains a single number that is the minimum valid value (inclusive)."
-        },
-        "rdfs:subPropertyOf": "shex:numericFacet",
-        "rdfs:domain": "shex:NodeConstraint",
-        "rdfs:range": {
-          "owl:unionOf": [
-            "xsd:integer",
-            "xsd:decimal",
-            "xsd:double"
-          ]
-        }
-      },
-      {
         "@id": "shex:minlength",
         "@type": "rdf:Property",
         "rdfs:label": {
@@ -754,18 +680,6 @@
         "rdfs:subPropertyOf": "shex:stringFacet",
         "rdfs:domain": "shex:NodeConstraint",
         "rdfs:range": "xsd:integer"
-      },
-      {
-        "@id": "shex:name",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "name"
-        },
-        "rdfs:comment": {
-          "en": "Identifier of SemAct extension."
-        },
-        "rdfs:domain": "shex:SemAct",
-        "rdfs:range": "rdfs:Resource"
       },
       {
         "@id": "shex:nodeKind",
@@ -780,29 +694,6 @@
         "rdfs:range": "shex:NodeKind"
       },
       {
-        "@id": "shex:numericFacet",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": ""
-        },
-        "rdfs:comment": {
-          "en": "Abstract property of numeric facets on a NodeConstraint."
-        },
-        "rdfs:subPropertyOf": "shex:xsFacet"
-      },
-      {
-        "@id": "shex:object",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "object"
-        },
-        "rdfs:comment": {
-          "en": "The object of an Annotation."
-        },
-        "rdfs:domain": "shex:Annotation",
-        "rdfs:range": "rdfs:Resource"
-      },
-      {
         "@id": "shex:pattern",
         "@type": "rdf:Property",
         "rdfs:label": {
@@ -814,140 +705,6 @@
         "rdfs:subPropertyOf": "shex:stringFacet",
         "rdfs:domain": "shex:NodeConstraint",
         "rdfs:range": "xsd:string"
-      },
-      {
-        "@id": "shex:predicate",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "predicate"
-        },
-        "rdfs:comment": {
-          "en": "The predicate of a TripleConstraint or Annotation."
-        },
-        "rdfs:domain": {
-          "owl:unionOf": [
-            "shex:Annotation",
-            "shex:TripleConstraint"
-          ]
-        },
-        "rdfs:range": "rdfs:Resource"
-      },
-      {
-        "@id": "shex:semActs",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "semantic action"
-        },
-        "rdfs:comment": {
-          "en": "Semantic Actions on this TripleExpression."
-        },
-        "rdfs:domain": {
-          "owl:unionOf": [
-            "shex:EachOf",
-            "shex:OneOf",
-            "shex:TripleConstraint"
-          ]
-        },
-        "rdfs:range": "shex:SemAct"
-      },
-      {
-        "@id": "shex:shapes",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "shapes"
-        },
-        "rdfs:comment": {
-          "en": "Shapes in this Schema."
-        },
-        "rdfs:domain": "shex:Schema",
-        "rdfs:range": "shex:ShapeExpression"
-      },
-      {
-        "@id": "shex:shapeExpr",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "shape expression"
-        },
-        "rdfs:comment": {
-          "en": "Shape Expression referenced by this shape."
-        },
-        "rdfs:domain": "shex:ShapeNot",
-        "rdfs:range": "shex:ShapeExpression"
-      },
-      {
-        "@id": "shex:shapeExprs",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "shape expressions"
-        },
-        "rdfs:comment": {
-          "en": "A list of 2 or more Shape Expressions referenced by this shape."
-        },
-        "rdfs:subPropertyOf": "shex:shapeExpr",
-        "rdfs:domain": {
-          "owl:unionOf": [
-            "shex:ShapeAnd",
-            "shex:ShapeOr"
-          ]
-        },
-        "rdfs:range": "shex:ShapeExpression"
-      },
-      {
-        "@id": "shex:start",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "start"
-        },
-        "rdfs:comment": {
-          "en": "A ShapeExpression matched against the focus node prior to any other mapped expressions."
-        },
-        "rdfs:domain": "shex:Schema",
-        "rdfs:range": "shex:ShapeExpression"
-      },
-      {
-        "@id": "shex:startActs",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "start actions"
-        },
-        "rdfs:comment": {
-          "en": "Semantic Actions run on the Schema."
-        },
-        "rdfs:domain": "shex:Schema",
-        "rdfs:range": "shex:SemAct"
-      },
-      {
-        "@id": "shex:stem",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "stem"
-        },
-        "rdfs:comment": {
-          "en": "A stem value used for matching or excluding values."
-        },
-        "rdfs:domain": {
-          "owl:unionOf": [
-            "shex:Stem",
-            "shex:StemRange"
-          ]
-        },
-        "rdfs:range": {
-          "owl:unionOf": [
-            "xsd:anyUri",
-            "shex:Wildcard"
-          ]
-        }
-      },
-      {
-        "@id": "shex:stringFacet",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": ""
-        },
-        "rdfs:comment": {
-          "en": "An abstract property of string facets on a NodeConstraint."
-        },
-        "rdfs:subPropertyOf": "shex:xsFacet"
       },
       {
         "@id": "shex:totaldigits",
@@ -981,6 +738,194 @@
         }
       },
       {
+        "@id": "shex:xsFacet",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": ""
+        },
+        "rdfs:comment": {
+          "en": "An abstract property of string and numeric facets on a NodeConstraint."
+        },
+        "rdfs:domain": "shex:NodeConstraint"
+      },
+      {
+        "@id": "shex:shapes",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "shapes"
+        },
+        "rdfs:comment": {
+          "en": "Shapes in this Schema."
+        },
+        "rdfs:domain": "shex:Schema",
+        "rdfs:range": "shex:ShapeExpression"
+      },
+      {
+        "@id": "shex:start",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "start"
+        },
+        "rdfs:comment": {
+          "en": "A ShapeExpression matched against the focus node prior to any other mapped expressions."
+        },
+        "rdfs:domain": "shex:Schema",
+        "rdfs:range": "shex:ShapeExpression"
+      },
+      {
+        "@id": "shex:startActs",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "start actions"
+        },
+        "rdfs:comment": {
+          "en": "Semantic Actions run on the Schema."
+        },
+        "rdfs:domain": "shex:Schema",
+        "rdfs:range": "shex:SemAct"
+      },
+      {
+        "@id": "shex:code",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "code"
+        },
+        "rdfs:comment": {
+          "en": "Code executed by Semantic Action."
+        },
+        "rdfs:domain": "shex:SemAct",
+        "rdfs:range": "xsd:string"
+      },
+      {
+        "@id": "shex:name",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "name"
+        },
+        "rdfs:comment": {
+          "en": "Identifier of SemAct extension."
+        },
+        "rdfs:domain": "shex:SemAct",
+        "rdfs:range": "rdfs:Resource"
+      },
+      {
+        "@id": "shex:closed",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "closed"
+        },
+        "rdfs:comment": {
+          "en": "Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints."
+        },
+        "rdfs:domain": "shex:Shape",
+        "rdfs:range": "xsd:boolean"
+      },
+      {
+        "@id": "shex:expression",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "expression"
+        },
+        "rdfs:comment": {
+          "en": "Expression associated with the TripleExpression."
+        },
+        "rdfs:domain": "shex:Shape",
+        "rdfs:range": "shex:TripleExpression"
+      },
+      {
+        "@id": "shex:extra",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "extra"
+        },
+        "rdfs:comment": {
+          "en": "Properties which may have extra values beyond those matched through a constraint."
+        },
+        "rdfs:domain": "shex:Shape",
+        "rdfs:range": "rdfs:Resource"
+      },
+      {
+        "@id": "shex:shapeExprs",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "shape expressions"
+        },
+        "rdfs:comment": {
+          "en": "A list of 2 or more Shape Expressions referenced by this shape."
+        },
+        "rdfs:subPropertyOf": "shex:shapeExpr",
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "shex:ShapeAnd",
+            "shex:ShapeOr"
+          ]
+        },
+        "rdfs:range": "shex:ShapeExpression"
+      },
+      {
+        "@id": "shex:shapeExpr",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "shape expression"
+        },
+        "rdfs:comment": {
+          "en": "Shape Expression referenced by this shape."
+        },
+        "rdfs:domain": "shex:ShapeNot",
+        "rdfs:range": "shex:ShapeExpression"
+      },
+      {
+        "@id": "shex:stem",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "stem"
+        },
+        "rdfs:comment": {
+          "en": "A stem value used for matching or excluding values."
+        },
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "shex:Stem",
+            "shex:StemRange"
+          ]
+        },
+        "rdfs:range": {
+          "owl:unionOf": [
+            "xsd:anyUri",
+            "shex:Wildcard"
+          ]
+        }
+      },
+      {
+        "@id": "shex:exclusion",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "exclusion"
+        },
+        "rdfs:comment": {
+          "en": "Values that are excluded from value matching."
+        },
+        "rdfs:domain": "shex:StemRange",
+        "rdfs:range": {
+          "owl:unionOf": [
+            "rdfs:Resource",
+            "shex:Stem"
+          ]
+        }
+      },
+      {
+        "@id": "shex:inverse",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "inverse"
+        },
+        "rdfs:comment": {
+          "en": "Constrains the subject of a triple, rather than the object."
+        },
+        "rdfs:domain": "shex:TripleConstraint",
+        "rdfs:range": "xsd:boolean"
+      },
+      {
         "@id": "shex:valueExpr",
         "@type": "rdf:Property",
         "rdfs:label": {
@@ -993,15 +938,26 @@
         "rdfs:range": "shex:ShapeExpression"
       },
       {
-        "@id": "shex:xsFacet",
+        "@id": "shex:numericFacet",
         "@type": "rdf:Property",
         "rdfs:label": {
           "en": ""
         },
         "rdfs:comment": {
-          "en": "An abstract property of string and numeric facets on a NodeConstraint."
+          "en": "Abstract property of numeric facets on a NodeConstraint."
         },
-        "rdfs:domain": "shex:NodeConstraint"
+        "rdfs:subPropertyOf": "shex:xsFacet"
+      },
+      {
+        "@id": "shex:stringFacet",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": ""
+        },
+        "rdfs:comment": {
+          "en": "An abstract property of string facets on a NodeConstraint."
+        },
+        "rdfs:subPropertyOf": "shex:xsFacet"
       }
     ],
     "rdfs_instances": [

--- a/ns/index.html
+++ b/ns/index.html
@@ -22,7 +22,7 @@ var respecConfig = {
     },
     specStatus: "base",
     shortName: "shexns",
-    publishDate:  "2017-01-18",
+    publishDate:  "2017-01-22",
     edDraftURI: "http://shexspec.github.io/ns/",
     // lcEnd: "3000-01-01",
     // crEnd: "3000-01-01",
@@ -98,9 +98,9 @@ var respecConfig = {
         <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2017-01-18</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2017-01-22</time></dd>
         <dt>Version Info:</dt>
-        <dd><a href="https://github.com/shexSpec/shexspec.github.io/commit/af16ff5da669b204026a80287d211f9b4ffaf2ef" property="owl:versionInfo">https://github.com/shexSpec/shexspec.github.io/commit/af16ff5da669b204026a80287d211f9b4ffaf2ef</a></dd>
+        <dd><a href="https://github.com/shexSpec/shexspec.github.io/commit/8699b802204fe7c964ed4dff965ceb54d3c080f3" property="owl:versionInfo">https://github.com/shexSpec/shexspec.github.io/commit/8699b802204fe7c964ed4dff965ceb54d3c080f3</a></dd>
         <dt>See Also:</dt>
           <dd><a href="https://shexspec.github.io/spec" property="rdfs:seeAlso">https://shexspec.github.io/spec</a></dd>
       </dl>
@@ -297,90 +297,33 @@ var respecConfig = {
       <h2>Property Definitions</h2>
       <p>The following are property definitions in the <code>shex</code> namespace:</p>
       <table class="rdfs-definition">
-        <tr><td class="bold">annotation</td>
-          <td resource="shex:annotation" typeof="rdf:Property">
-            <em property="rdfs:label">annotation</em>
-            <p property="rdfs:comment">Annotations on a TripleExpression.</p>
+        <tr><td class="bold">object</td>
+          <td resource="shex:object" typeof="rdf:Property">
+            <em property="rdfs:label">object</em>
+            <p property="rdfs:comment">The object of an Annotation.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:Annotation">shex:Annotation</dd>
+                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Annotation">shex:Annotation</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">predicate</td>
+          <td resource="shex:predicate" typeof="rdf:Property">
+            <em property="rdfs:label">predicate</em>
+            <p property="rdfs:comment">The predicate of a TripleConstraint or Annotation.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="_:">
                         Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:Annotation">shex:Annotation</span>
                         <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
                       </dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">closed</td>
-          <td resource="shex:closed" typeof="rdf:Property">
-            <em property="rdfs:label">closed</em>
-            <p property="rdfs:comment">Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="xsd:boolean">xsd:boolean</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">code</td>
-          <td resource="shex:code" typeof="rdf:Property">
-            <em property="rdfs:label">code</em>
-            <p property="rdfs:comment">Code executed by Semantic Action.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="xsd:string">xsd:string</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:SemAct">shex:SemAct</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">datatype</td>
-          <td resource="shex:datatype" typeof="rdf:Property">
-            <em property="rdfs:label">datatype</em>
-            <p property="rdfs:comment">A datatype constraint.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="rdfs:Datatype">rdfs:Datatype</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">exclusion</td>
-          <td resource="shex:exclusion" typeof="rdf:Property">
-            <em property="rdfs:label">exclusion</em>
-            <p property="rdfs:comment">Values that are excluded from value matching.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="rdfs:Resource">rdfs:Resource</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:Stem">shex:Stem</span>
-                      </dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:StemRange">shex:StemRange</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">expression</td>
-          <td resource="shex:expression" typeof="rdf:Property">
-            <em property="rdfs:label">expression</em>
-            <p property="rdfs:comment">Expression associated with the TripleExpression.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:TripleExpression">shex:TripleExpression</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
               </dl>
           </td>
         </tr>
@@ -401,16 +344,88 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">extra</td>
-          <td resource="shex:extra" typeof="rdf:Property">
-            <em property="rdfs:label">extra</em>
-            <p property="rdfs:comment">Properties which may have extra values beyond those matched through a constraint.</p>
+        <tr><td class="bold">annotation</td>
+          <td resource="shex:annotation" typeof="rdf:Property">
+            <em property="rdfs:label">annotation</em>
+            <p property="rdfs:comment">Annotations on a TripleExpression.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
+                      <dd property="rdfs:range" resource="shex:Annotation">shex:Annotation</dd>
                   <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
+                      </dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">max</td>
+          <td resource="shex:max" typeof="rdf:Property">
+            <em property="rdfs:label">maximum cardinality</em>
+            <p property="rdfs:comment">Maximum number of times this TripleExpression may match.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:integer">xsd:integer</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
+                      </dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">min</td>
+          <td resource="shex:min" typeof="rdf:Property">
+            <em property="rdfs:label">minimum cardinatliy</em>
+            <p property="rdfs:comment">Minimum number of times this TripleExpression may match.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:integer">xsd:integer</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
+                      </dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">semActs</td>
+          <td resource="shex:semActs" typeof="rdf:Property">
+            <em property="rdfs:label">semantic action</em>
+            <p property="rdfs:comment">Semantic Actions on this TripleExpression.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:SemAct">shex:SemAct</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
+                      </dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">datatype</td>
+          <td resource="shex:datatype" typeof="rdf:Property">
+            <em property="rdfs:label">datatype</em>
+            <p property="rdfs:comment">A datatype constraint.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:Datatype">xsd:Datatype</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
               </dl>
           </td>
         </tr>
@@ -429,19 +444,6 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">inverse</td>
-          <td resource="shex:inverse" typeof="rdf:Property">
-            <em property="rdfs:label">inverse</em>
-            <p property="rdfs:comment">Constrains the subject of a triple, rather than the object.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="xsd:boolean">xsd:boolean</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:TripleConstraint">shex:TripleConstraint</dd>
-              </dl>
-          </td>
-        </tr>
         <tr><td class="bold">length</td>
           <td resource="shex:length" typeof="rdf:Property">
             <em property="rdfs:label">length</em>
@@ -454,22 +456,6 @@ var respecConfig = {
                       <dd property="rdfs:range" resource="xsd:integer">xsd:integer</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">max</td>
-          <td resource="shex:max" typeof="rdf:Property">
-            <em property="rdfs:label">maximum cardinality</em>
-            <p property="rdfs:comment">Maximum number of times this TripleExpression may match.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
-                      </dd>
               </dl>
           </td>
         </tr>
@@ -496,7 +482,7 @@ var respecConfig = {
         <tr><td class="bold">maxinclusive</td>
           <td resource="shex:maxinclusive" typeof="rdf:Property">
             <em property="rdfs:label">max inclusive</em>
-            <p property="rdfs:comment">An atomic property that contains a single number that is the maximum valid value (inclusive).</p>
+            <p property="rdfs:comment">An atomic property that contains a single number that is the minimum valid value (inclusive).</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:subPropertyOf</dt>
@@ -528,64 +514,6 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">min</td>
-          <td resource="shex:min" typeof="rdf:Property">
-            <em property="rdfs:label">minimum cardinatliy</em>
-            <p property="rdfs:comment">Minimum number of times this TripleExpression may match.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="xsd:integer">xsd:integer</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
-                      </dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">minexclusive</td>
-          <td resource="shex:minexclusive" typeof="rdf:Property">
-            <em property="rdfs:label">min exclusive</em>
-            <p property="rdfs:comment">An atomic property that contains a single number that is the minimum valid value (exclusive).</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subPropertyOf</dt>
-                      <dd property="rdfs:subPropertyOf" resource="shex:numericFacet">shex:numericFacet</dd>
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="xsd:integer">xsd:integer</span>
-                        <span property="owl:unionOf" inlist=true resource="xsd:decimal">xsd:decimal</span>
-                        <span property="owl:unionOf" inlist=true resource="xsd:double">xsd:double</span>
-                      </dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">mininclusive</td>
-          <td resource="shex:mininclusive" typeof="rdf:Property">
-            <em property="rdfs:label">min inclusive</em>
-            <p property="rdfs:comment">An atomic property that contains a single number that is the minimum valid value (inclusive).</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subPropertyOf</dt>
-                      <dd property="rdfs:subPropertyOf" resource="shex:numericFacet">shex:numericFacet</dd>
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="xsd:integer">xsd:integer</span>
-                        <span property="owl:unionOf" inlist=true resource="xsd:decimal">xsd:decimal</span>
-                        <span property="owl:unionOf" inlist=true resource="xsd:double">xsd:double</span>
-                      </dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
-              </dl>
-          </td>
-        </tr>
         <tr><td class="bold">minlength</td>
           <td resource="shex:minlength" typeof="rdf:Property">
             <em property="rdfs:label">min length</em>
@@ -598,19 +526,6 @@ var respecConfig = {
                       <dd property="rdfs:range" resource="xsd:integer">xsd:integer</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">name</td>
-          <td resource="shex:name" typeof="rdf:Property">
-            <em property="rdfs:label">name</em>
-            <p property="rdfs:comment">Identifier of SemAct extension.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:SemAct">shex:SemAct</dd>
               </dl>
           </td>
         </tr>
@@ -627,30 +542,6 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">numericFacet</td>
-          <td resource="shex:numericFacet" typeof="rdf:Property">
-            <em property="rdfs:label"></em>
-            <p property="rdfs:comment">Abstract property of numeric facets on a NodeConstraint.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subPropertyOf</dt>
-                      <dd property="rdfs:subPropertyOf" resource="shex:xsFacet">shex:xsFacet</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">object</td>
-          <td resource="shex:object" typeof="rdf:Property">
-            <em property="rdfs:label">object</em>
-            <p property="rdfs:comment">The object of an Annotation.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Annotation">shex:Annotation</dd>
-              </dl>
-          </td>
-        </tr>
         <tr><td class="bold">pattern</td>
           <td resource="shex:pattern" typeof="rdf:Property">
             <em property="rdfs:label">pattern</em>
@@ -663,144 +554,6 @@ var respecConfig = {
                       <dd property="rdfs:range" resource="xsd:string">xsd:string</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">predicate</td>
-          <td resource="shex:predicate" typeof="rdf:Property">
-            <em property="rdfs:label">predicate</em>
-            <p property="rdfs:comment">The predicate of a TripleConstraint or Annotation.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:Annotation">shex:Annotation</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
-                      </dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">semActs</td>
-          <td resource="shex:semActs" typeof="rdf:Property">
-            <em property="rdfs:label">semantic action</em>
-            <p property="rdfs:comment">Semantic Actions on this TripleExpression.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:SemAct">shex:SemAct</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:EachOf">shex:EachOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:OneOf">shex:OneOf</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:TripleConstraint">shex:TripleConstraint</span>
-                      </dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">shapes</td>
-          <td resource="shex:shapes" typeof="rdf:Property">
-            <em property="rdfs:label">shapes</em>
-            <p property="rdfs:comment">Shapes in this Schema.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">shapeExpr</td>
-          <td resource="shex:shapeExpr" typeof="rdf:Property">
-            <em property="rdfs:label">shape expression</em>
-            <p property="rdfs:comment">Shape Expression referenced by this shape.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:ShapeNot">shex:ShapeNot</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">shapeExprs</td>
-          <td resource="shex:shapeExprs" typeof="rdf:Property">
-            <em property="rdfs:label">shape expressions</em>
-            <p property="rdfs:comment">A list of 2 or more Shape Expressions referenced by this shape.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subPropertyOf</dt>
-                      <dd property="rdfs:subPropertyOf" resource="shex:shapeExpr">shex:shapeExpr</dd>
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:ShapeAnd">shex:ShapeAnd</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:ShapeOr">shex:ShapeOr</span>
-                      </dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">start</td>
-          <td resource="shex:start" typeof="rdf:Property">
-            <em property="rdfs:label">start</em>
-            <p property="rdfs:comment">A ShapeExpression matched against the focus node prior to any other mapped expressions.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">startActs</td>
-          <td resource="shex:startActs" typeof="rdf:Property">
-            <em property="rdfs:label">start actions</em>
-            <p property="rdfs:comment">Semantic Actions run on the Schema.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:SemAct">shex:SemAct</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">stem</td>
-          <td resource="shex:stem" typeof="rdf:Property">
-            <em property="rdfs:label">stem</em>
-            <p property="rdfs:comment">A stem value used for matching or excluding values.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="xsd:anyUri">xsd:anyUri</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:Wildcard">shex:Wildcard</span>
-                      </dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="shex:Stem">shex:Stem</span>
-                        <span property="owl:unionOf" inlist=true resource="shex:StemRange">shex:StemRange</span>
-                      </dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">stringFacet</td>
-          <td resource="shex:stringFacet" typeof="rdf:Property">
-            <em property="rdfs:label"></em>
-            <p property="rdfs:comment">An abstract property of string facets on a NodeConstraint.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subPropertyOf</dt>
-                      <dd property="rdfs:subPropertyOf" resource="shex:xsFacet">shex:xsFacet</dd>
               </dl>
           </td>
         </tr>
@@ -837,6 +590,204 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
+        <tr><td class="bold">xsFacet</td>
+          <td resource="shex:xsFacet" typeof="rdf:Property">
+            <em property="rdfs:label"></em>
+            <p property="rdfs:comment">An abstract property of string and numeric facets on a NodeConstraint.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">shapes</td>
+          <td resource="shex:shapes" typeof="rdf:Property">
+            <em property="rdfs:label">shapes</em>
+            <p property="rdfs:comment">Shapes in this Schema.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">start</td>
+          <td resource="shex:start" typeof="rdf:Property">
+            <em property="rdfs:label">start</em>
+            <p property="rdfs:comment">A ShapeExpression matched against the focus node prior to any other mapped expressions.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">startActs</td>
+          <td resource="shex:startActs" typeof="rdf:Property">
+            <em property="rdfs:label">start actions</em>
+            <p property="rdfs:comment">Semantic Actions run on the Schema.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:SemAct">shex:SemAct</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">code</td>
+          <td resource="shex:code" typeof="rdf:Property">
+            <em property="rdfs:label">code</em>
+            <p property="rdfs:comment">Code executed by Semantic Action.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:string">xsd:string</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:SemAct">shex:SemAct</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">name</td>
+          <td resource="shex:name" typeof="rdf:Property">
+            <em property="rdfs:label">name</em>
+            <p property="rdfs:comment">Identifier of SemAct extension.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:SemAct">shex:SemAct</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">closed</td>
+          <td resource="shex:closed" typeof="rdf:Property">
+            <em property="rdfs:label">closed</em>
+            <p property="rdfs:comment">Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:boolean">xsd:boolean</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">expression</td>
+          <td resource="shex:expression" typeof="rdf:Property">
+            <em property="rdfs:label">expression</em>
+            <p property="rdfs:comment">Expression associated with the TripleExpression.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:TripleExpression">shex:TripleExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">extra</td>
+          <td resource="shex:extra" typeof="rdf:Property">
+            <em property="rdfs:label">extra</em>
+            <p property="rdfs:comment">Properties which may have extra values beyond those matched through a constraint.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">shapeExprs</td>
+          <td resource="shex:shapeExprs" typeof="rdf:Property">
+            <em property="rdfs:label">shape expressions</em>
+            <p property="rdfs:comment">A list of 2 or more Shape Expressions referenced by this shape.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:subPropertyOf</dt>
+                      <dd property="rdfs:subPropertyOf" resource="shex:shapeExpr">shex:shapeExpr</dd>
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:ShapeAnd">shex:ShapeAnd</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:ShapeOr">shex:ShapeOr</span>
+                      </dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">shapeExpr</td>
+          <td resource="shex:shapeExpr" typeof="rdf:Property">
+            <em property="rdfs:label">shape expression</em>
+            <p property="rdfs:comment">Shape Expression referenced by this shape.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:ShapeNot">shex:ShapeNot</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">stem</td>
+          <td resource="shex:stem" typeof="rdf:Property">
+            <em property="rdfs:label">stem</em>
+            <p property="rdfs:comment">A stem value used for matching or excluding values.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="xsd:anyUri">xsd:anyUri</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:Wildcard">shex:Wildcard</span>
+                      </dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:Stem">shex:Stem</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:StemRange">shex:StemRange</span>
+                      </dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">exclusion</td>
+          <td resource="shex:exclusion" typeof="rdf:Property">
+            <em property="rdfs:label">exclusion</em>
+            <p property="rdfs:comment">Values that are excluded from value matching.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="rdfs:Resource">rdfs:Resource</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:Stem">shex:Stem</span>
+                      </dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:StemRange">shex:StemRange</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">inverse</td>
+          <td resource="shex:inverse" typeof="rdf:Property">
+            <em property="rdfs:label">inverse</em>
+            <p property="rdfs:comment">Constrains the subject of a triple, rather than the object.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:boolean">xsd:boolean</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:TripleConstraint">shex:TripleConstraint</dd>
+              </dl>
+          </td>
+        </tr>
         <tr><td class="bold">valueExpr</td>
           <td resource="shex:valueExpr" typeof="rdf:Property">
             <em property="rdfs:label">value expression</em>
@@ -850,14 +801,25 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">xsFacet</td>
-          <td resource="shex:xsFacet" typeof="rdf:Property">
+        <tr><td class="bold">numericFacet</td>
+          <td resource="shex:numericFacet" typeof="rdf:Property">
             <em property="rdfs:label"></em>
-            <p property="rdfs:comment">An abstract property of string and numeric facets on a NodeConstraint.</p>
+            <p property="rdfs:comment">Abstract property of numeric facets on a NodeConstraint.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
+                  <dt>rdfs:subPropertyOf</dt>
+                      <dd property="rdfs:subPropertyOf" resource="shex:xsFacet">shex:xsFacet</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">stringFacet</td>
+          <td resource="shex:stringFacet" typeof="rdf:Property">
+            <em property="rdfs:label"></em>
+            <p property="rdfs:comment">An abstract property of string facets on a NodeConstraint.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:subPropertyOf</dt>
+                      <dd property="rdfs:subPropertyOf" resource="shex:xsFacet">shex:xsFacet</dd>
               </dl>
           </td>
         </tr>
@@ -1004,7 +966,7 @@ var respecConfig = {
         <dt>datatype</dt>
         <dd>
             shex:datatype
-            with string values interpreted as @id
+            with string values interpreted as xsd:Datatype
         </dd>
         <dt>exclusion</dt>
         <dd>
@@ -1066,6 +1028,7 @@ var respecConfig = {
         <dt>max</dt>
         <dd>
             shex:max
+            with string values interpreted as xsd:integer
         </dd>
         <dt>maxexclusive</dt>
         <dd>
@@ -1085,16 +1048,6 @@ var respecConfig = {
         <dt>min</dt>
         <dd>
             shex:min
-            with string values interpreted as xsd:integer
-        </dd>
-        <dt>minexclusive</dt>
-        <dd>
-            shex:minexclusive
-            with string values interpreted as xsd:integer
-        </dd>
-        <dt>mininclusive</dt>
-        <dd>
-            shex:mininclusive
             with string values interpreted as xsd:integer
         </dd>
         <dt>minlength</dt>

--- a/ns/install.sh
+++ b/ns/install.sh
@@ -1,0 +1,2 @@
+sudo apt-get install ruby
+sudo gem install erubis

--- a/ns/shex.shexc
+++ b/ns/shex.shexc
@@ -1,0 +1,108 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX shex: <http://shex.io/ns/shex#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+#ShExc definition of ShExJ
+#Shape Expression Vocabulary Terms
+#This document describes the RDFS vocabulary description used in the Shape Expression Language (ShEx) [[shex]] along with the default JSON-LD Context.
+#Date: 2017-01-22
+#Imports 
+#Version https://github.com/shexSpec/shexspec.github.io/commit/8699b802204fe7c964ed4dff965ceb54d3c080f3
+#See also <https://shexspec.github.io/spec>
+  
+
+start = @shex:Schema
+
+
+# Shape definitions
+shex:Annotation {
+  shex:object IRI ;
+  shex:predicate IRI ;
+}
+shex:EachOf {
+  #// rdfs:subClassOf shex:TripleExpression;
+  shex:expressions @shex:TripleExpression+ ;
+  shex:annotation @shex:Annotation* ;
+  shex:max xsd:integer ;
+  shex:min xsd:integer ;
+  shex:semActs @shex:SemAct* ;
+}
+shex:NodeConstraint {
+  #// rdfs:subClassOf shex:ShapeExpression;
+  shex:datatype xsd:Datatype? ;
+  shex:fractiondigits xsd:integer? ;
+  shex:length xsd:integer? ;
+  shex:maxexclusive (xsd:integer OR xsd:decimal OR xsd:double)? ;
+  shex:maxinclusive (xsd:integer OR xsd:decimal OR xsd:double)? ;
+  shex:maxlength xsd:integer? ;
+  shex:minlength xsd:integer? ;
+  shex:nodeKind @shex:NodeKind? ;
+  shex:pattern xsd:string? ;
+  shex:totaldigits xsd:integer? ;
+  shex:values (IRI OR @shex:Stem OR @shex:StemRange)* ;
+}
+shex:NodeKind {
+}
+shex:OneOf {
+  #// rdfs:subClassOf shex:TripleExpression;
+  shex:expressions @shex:TripleExpression+ ;
+  shex:annotation @shex:Annotation* ;
+  shex:max xsd:integer ;
+  shex:min xsd:integer ;
+  shex:semActs @shex:SemAct* ;
+}
+shex:Schema {
+  shex:shapes @shex:ShapeExpression? ;
+  shex:start @shex:ShapeExpression? ;
+  shex:startActs @shex:SemAct* ;
+}
+shex:SemAct {
+  shex:code xsd:string ;
+  shex:name IRI ;
+}
+shex:Shape {
+  #// rdfs:subClassOf shex:ShapeExpression;
+  shex:closed xsd:boolean? ;
+  shex:expression @shex:TripleExpression* ;
+  shex:extra IRI* ;
+}
+shex:ShapeAnd {
+  #// rdfs:subClassOf shex:ShapeExpression;
+  shex:shapeExprs @shex:ShapeExpression+ ;
+}
+shex:ShapeExpression {
+  (&shex:NodeConstraint | &shex:Shape | &shex:ShapeAnd | &shex:ShapeExternal | &shex:ShapeNot | &shex:ShapeOr)
+}
+shex:ShapeExternal {
+  #// rdfs:subClassOf shex:ShapeExpression;
+}
+shex:ShapeNot {
+  #// rdfs:subClassOf shex:ShapeExpression;
+  shex:shapeExpr @shex:ShapeExpression ;
+}
+shex:ShapeOr {
+  #// rdfs:subClassOf shex:ShapeExpression;
+  shex:shapeExprs @shex:ShapeExpression+ ;
+}
+shex:Stem {
+  shex:stem (xsd:anyUri OR @shex:Wildcard) ;
+}
+shex:StemRange {
+  shex:stem (xsd:anyUri OR @shex:Wildcard) ;
+  shex:exclusion (IRI OR @shex:Stem)* ;
+}
+shex:TripleConstraint {
+  #// rdfs:subClassOf shex:TripleExpression;
+  shex:predicate IRI ;
+  shex:annotation @shex:Annotation* ;
+  shex:max xsd:integer ;
+  shex:min xsd:integer ;
+  shex:semActs @shex:SemAct* ;
+  shex:inverse xsd:boolean? ;
+  shex:valueExpr @shex:ShapeExpression ;
+}
+shex:TripleExpression {
+  (&shex:EachOf | &shex:OneOf | &shex:TripleConstraint)
+}
+shex:Wildcard {
+}

--- a/ns/shex.ttl
+++ b/ns/shex.ttl
@@ -7,9 +7,9 @@
 shex: a owl:Ontology;
   dc:title "Shape Expression Vocabulary Terms"@en;
   dc:description """This document describes the RDFS vocabulary description used in the Shape Expression Language (ShEx) [[shex]] along with the default JSON-LD Context."""@en;
-  dc:date "2017-01-18"^^xsd:date;
+  dc:date "2017-01-22"^^xsd:date;
   dc:imports ;
-  owl:versionInfo <https://github.com/shexSpec/shexspec.github.io/commit/af16ff5da669b204026a80287d211f9b4ffaf2ef>;
+  owl:versionInfo <https://github.com/shexSpec/shexspec.github.io/commit/8699b802204fe7c964ed4dff965ceb54d3c080f3>;
   rdfs:seeAlso <https://shexspec.github.io/spec>;
   .
 
@@ -98,41 +98,17 @@ shex:Wildcard a rdfs:Class;
   rdfs:isDefinedBy shex: .
 
 # Property definitions
-shex:annotation a rdf:Property;
-  rdfs:label "annotation"@en;
-  rdfs:comment """Annotations on a TripleExpression."""@en;
-  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
-  rdfs:range shex:Annotation;
+shex:object a rdf:Property;
+  rdfs:label "object"@en;
+  rdfs:comment """The object of an Annotation."""@en;
+  rdfs:domain shex:Annotation;
+  rdfs:range rdfs:Resource;
   rdfs:isDefinedBy shex: .
-shex:closed a rdf:Property;
-  rdfs:label "closed"@en;
-  rdfs:comment """Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints."""@en;
-  rdfs:domain shex:Shape;
-  rdfs:range xsd:boolean;
-  rdfs:isDefinedBy shex: .
-shex:code a rdf:Property;
-  rdfs:label "code"@en;
-  rdfs:comment """Code executed by Semantic Action."""@en;
-  rdfs:domain shex:SemAct;
-  rdfs:range xsd:string;
-  rdfs:isDefinedBy shex: .
-shex:datatype a rdf:Property;
-  rdfs:label "datatype"@en;
-  rdfs:comment """A datatype constraint."""@en;
-  rdfs:domain shex:NodeConstraint;
-  rdfs:range rdfs:Datatype;
-  rdfs:isDefinedBy shex: .
-shex:exclusion a rdf:Property;
-  rdfs:label "exclusion"@en;
-  rdfs:comment """Values that are excluded from value matching."""@en;
-  rdfs:domain shex:StemRange;
-  rdfs:range [ owl:unionOf (rdfs:Resource shex:Stem)];
-  rdfs:isDefinedBy shex: .
-shex:expression a rdf:Property;
-  rdfs:label "expression"@en;
-  rdfs:comment """Expression associated with the TripleExpression."""@en;
-  rdfs:domain shex:Shape;
-  rdfs:range shex:TripleExpression;
+shex:predicate a rdf:Property;
+  rdfs:label "predicate"@en;
+  rdfs:comment """The predicate of a TripleConstraint or Annotation."""@en;
+  rdfs:domain [ owl:unionOf (shex:Annotation shex:TripleConstraint)];
+  rdfs:range rdfs:Resource;
   rdfs:isDefinedBy shex: .
 shex:expressions a rdf:Property;
   rdfs:label "expressions"@en;
@@ -140,11 +116,35 @@ shex:expressions a rdf:Property;
   rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf)];
   rdfs:range shex:TripleExpression;
   rdfs:isDefinedBy shex: .
-shex:extra a rdf:Property;
-  rdfs:label "extra"@en;
-  rdfs:comment """Properties which may have extra values beyond those matched through a constraint."""@en;
-  rdfs:domain shex:Shape;
-  rdfs:range rdfs:Resource;
+shex:annotation a rdf:Property;
+  rdfs:label "annotation"@en;
+  rdfs:comment """Annotations on a TripleExpression."""@en;
+  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
+  rdfs:range shex:Annotation;
+  rdfs:isDefinedBy shex: .
+shex:max a rdf:Property;
+  rdfs:label "maximum cardinality"@en;
+  rdfs:comment """Maximum number of times this TripleExpression may match."""@en;
+  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
+  rdfs:range xsd:integer;
+  rdfs:isDefinedBy shex: .
+shex:min a rdf:Property;
+  rdfs:label "minimum cardinatliy"@en;
+  rdfs:comment """Minimum number of times this TripleExpression may match."""@en;
+  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
+  rdfs:range xsd:integer;
+  rdfs:isDefinedBy shex: .
+shex:semActs a rdf:Property;
+  rdfs:label "semantic action"@en;
+  rdfs:comment """Semantic Actions on this TripleExpression."""@en;
+  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
+  rdfs:range shex:SemAct;
+  rdfs:isDefinedBy shex: .
+shex:datatype a rdf:Property;
+  rdfs:label "datatype"@en;
+  rdfs:comment """A datatype constraint."""@en;
+  rdfs:domain shex:NodeConstraint;
+  rdfs:range xsd:Datatype;
   rdfs:isDefinedBy shex: .
 shex:fractiondigits a rdf:Property;
   rdfs:label "fraction digits"@en;
@@ -153,23 +153,12 @@ shex:fractiondigits a rdf:Property;
   rdfs:domain shex:NodeConstraint;
   rdfs:range xsd:integer;
   rdfs:isDefinedBy shex: .
-shex:inverse a rdf:Property;
-  rdfs:label "inverse"@en;
-  rdfs:comment """Constrains the subject of a triple, rather than the object."""@en;
-  rdfs:domain shex:TripleConstraint;
-  rdfs:range xsd:boolean;
-  rdfs:isDefinedBy shex: .
 shex:length a rdf:Property;
   rdfs:label "length"@en;
   rdfs:comment """The exact length of the value of the cell."""@en;
   rdfs:subPropertyOf shex:stringFacet;
   rdfs:domain shex:NodeConstraint;
   rdfs:range xsd:integer;
-  rdfs:isDefinedBy shex: .
-shex:max a rdf:Property;
-  rdfs:label "maximum cardinality"@en;
-  rdfs:comment """Maximum number of times this TripleExpression may match."""@en;
-  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
   rdfs:isDefinedBy shex: .
 shex:maxexclusive a rdf:Property;
   rdfs:label "max exclusive"@en;
@@ -180,7 +169,7 @@ shex:maxexclusive a rdf:Property;
   rdfs:isDefinedBy shex: .
 shex:maxinclusive a rdf:Property;
   rdfs:label "max inclusive"@en;
-  rdfs:comment """An atomic property that contains a single number that is the maximum valid value (inclusive)."""@en;
+  rdfs:comment """An atomic property that contains a single number that is the minimum valid value (inclusive)."""@en;
   rdfs:subPropertyOf shex:numericFacet;
   rdfs:domain shex:NodeConstraint;
   rdfs:range [ owl:unionOf (xsd:integer xsd:decimal xsd:double)];
@@ -192,26 +181,6 @@ shex:maxlength a rdf:Property;
   rdfs:domain shex:NodeConstraint;
   rdfs:range xsd:integer;
   rdfs:isDefinedBy shex: .
-shex:min a rdf:Property;
-  rdfs:label "minimum cardinatliy"@en;
-  rdfs:comment """Minimum number of times this TripleExpression may match."""@en;
-  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
-  rdfs:range xsd:integer;
-  rdfs:isDefinedBy shex: .
-shex:minexclusive a rdf:Property;
-  rdfs:label "min exclusive"@en;
-  rdfs:comment """An atomic property that contains a single number that is the minimum valid value (exclusive)."""@en;
-  rdfs:subPropertyOf shex:numericFacet;
-  rdfs:domain shex:NodeConstraint;
-  rdfs:range [ owl:unionOf (xsd:integer xsd:decimal xsd:double)];
-  rdfs:isDefinedBy shex: .
-shex:mininclusive a rdf:Property;
-  rdfs:label "min inclusive"@en;
-  rdfs:comment """An atomic property that contains a single number that is the minimum valid value (inclusive)."""@en;
-  rdfs:subPropertyOf shex:numericFacet;
-  rdfs:domain shex:NodeConstraint;
-  rdfs:range [ owl:unionOf (xsd:integer xsd:decimal xsd:double)];
-  rdfs:isDefinedBy shex: .
 shex:minlength a rdf:Property;
   rdfs:label "min length"@en;
   rdfs:comment """An atomic property that contains a single integer that is the minimum length of the value."""@en;
@@ -219,28 +188,11 @@ shex:minlength a rdf:Property;
   rdfs:domain shex:NodeConstraint;
   rdfs:range xsd:integer;
   rdfs:isDefinedBy shex: .
-shex:name a rdf:Property;
-  rdfs:label "name"@en;
-  rdfs:comment """Identifier of SemAct extension."""@en;
-  rdfs:domain shex:SemAct;
-  rdfs:range rdfs:Resource;
-  rdfs:isDefinedBy shex: .
 shex:nodeKind a rdf:Property;
   rdfs:label "node kind"@en;
   rdfs:comment """Restiction on the kind of node matched; restricted to the defined instances of NodeKind. One of shex:iri, shex:bnode, shex:literal, or shex:nonliteral."""@en;
   rdfs:domain shex:NodeConstraint;
   rdfs:range shex:NodeKind;
-  rdfs:isDefinedBy shex: .
-shex:numericFacet a rdf:Property;
-  rdfs:label ""@en;
-  rdfs:comment """Abstract property of numeric facets on a NodeConstraint."""@en;
-  rdfs:subPropertyOf shex:xsFacet;
-  rdfs:isDefinedBy shex: .
-shex:object a rdf:Property;
-  rdfs:label "object"@en;
-  rdfs:comment """The object of an Annotation."""@en;
-  rdfs:domain shex:Annotation;
-  rdfs:range rdfs:Resource;
   rdfs:isDefinedBy shex: .
 shex:pattern a rdf:Property;
   rdfs:label "pattern"@en;
@@ -248,60 +200,6 @@ shex:pattern a rdf:Property;
   rdfs:subPropertyOf shex:stringFacet;
   rdfs:domain shex:NodeConstraint;
   rdfs:range xsd:string;
-  rdfs:isDefinedBy shex: .
-shex:predicate a rdf:Property;
-  rdfs:label "predicate"@en;
-  rdfs:comment """The predicate of a TripleConstraint or Annotation."""@en;
-  rdfs:domain [ owl:unionOf (shex:Annotation shex:TripleConstraint)];
-  rdfs:range rdfs:Resource;
-  rdfs:isDefinedBy shex: .
-shex:semActs a rdf:Property;
-  rdfs:label "semantic action"@en;
-  rdfs:comment """Semantic Actions on this TripleExpression."""@en;
-  rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
-  rdfs:range shex:SemAct;
-  rdfs:isDefinedBy shex: .
-shex:shapes a rdf:Property;
-  rdfs:label "shapes"@en;
-  rdfs:comment """Shapes in this Schema."""@en;
-  rdfs:domain shex:Schema;
-  rdfs:range shex:ShapeExpression;
-  rdfs:isDefinedBy shex: .
-shex:shapeExpr a rdf:Property;
-  rdfs:label "shape expression"@en;
-  rdfs:comment """Shape Expression referenced by this shape."""@en;
-  rdfs:domain shex:ShapeNot;
-  rdfs:range shex:ShapeExpression;
-  rdfs:isDefinedBy shex: .
-shex:shapeExprs a rdf:Property;
-  rdfs:label "shape expressions"@en;
-  rdfs:comment """A list of 2 or more Shape Expressions referenced by this shape."""@en;
-  rdfs:subPropertyOf shex:shapeExpr;
-  rdfs:domain [ owl:unionOf (shex:ShapeAnd shex:ShapeOr)];
-  rdfs:range shex:ShapeExpression;
-  rdfs:isDefinedBy shex: .
-shex:start a rdf:Property;
-  rdfs:label "start"@en;
-  rdfs:comment """A ShapeExpression matched against the focus node prior to any other mapped expressions."""@en;
-  rdfs:domain shex:Schema;
-  rdfs:range shex:ShapeExpression;
-  rdfs:isDefinedBy shex: .
-shex:startActs a rdf:Property;
-  rdfs:label "start actions"@en;
-  rdfs:comment """Semantic Actions run on the Schema."""@en;
-  rdfs:domain shex:Schema;
-  rdfs:range shex:SemAct;
-  rdfs:isDefinedBy shex: .
-shex:stem a rdf:Property;
-  rdfs:label "stem"@en;
-  rdfs:comment """A stem value used for matching or excluding values."""@en;
-  rdfs:domain [ owl:unionOf (shex:Stem shex:StemRange)];
-  rdfs:range [ owl:unionOf (xsd:anyUri shex:Wildcard)];
-  rdfs:isDefinedBy shex: .
-shex:stringFacet a rdf:Property;
-  rdfs:label ""@en;
-  rdfs:comment """An abstract property of string facets on a NodeConstraint."""@en;
-  rdfs:subPropertyOf shex:xsFacet;
   rdfs:isDefinedBy shex: .
 shex:totaldigits a rdf:Property;
   rdfs:label "total digits"@en;
@@ -316,16 +214,105 @@ shex:values a rdf:Property;
   rdfs:domain shex:NodeConstraint;
   rdfs:range [ owl:unionOf (rdfs:Resource shex:Stem shex:StemRange)];
   rdfs:isDefinedBy shex: .
+shex:xsFacet a rdf:Property;
+  rdfs:label ""@en;
+  rdfs:comment """An abstract property of string and numeric facets on a NodeConstraint."""@en;
+  rdfs:domain shex:NodeConstraint;
+  rdfs:isDefinedBy shex: .
+shex:shapes a rdf:Property;
+  rdfs:label "shapes"@en;
+  rdfs:comment """Shapes in this Schema."""@en;
+  rdfs:domain shex:Schema;
+  rdfs:range shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
+shex:start a rdf:Property;
+  rdfs:label "start"@en;
+  rdfs:comment """A ShapeExpression matched against the focus node prior to any other mapped expressions."""@en;
+  rdfs:domain shex:Schema;
+  rdfs:range shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
+shex:startActs a rdf:Property;
+  rdfs:label "start actions"@en;
+  rdfs:comment """Semantic Actions run on the Schema."""@en;
+  rdfs:domain shex:Schema;
+  rdfs:range shex:SemAct;
+  rdfs:isDefinedBy shex: .
+shex:code a rdf:Property;
+  rdfs:label "code"@en;
+  rdfs:comment """Code executed by Semantic Action."""@en;
+  rdfs:domain shex:SemAct;
+  rdfs:range xsd:string;
+  rdfs:isDefinedBy shex: .
+shex:name a rdf:Property;
+  rdfs:label "name"@en;
+  rdfs:comment """Identifier of SemAct extension."""@en;
+  rdfs:domain shex:SemAct;
+  rdfs:range rdfs:Resource;
+  rdfs:isDefinedBy shex: .
+shex:closed a rdf:Property;
+  rdfs:label "closed"@en;
+  rdfs:comment """Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints."""@en;
+  rdfs:domain shex:Shape;
+  rdfs:range xsd:boolean;
+  rdfs:isDefinedBy shex: .
+shex:expression a rdf:Property;
+  rdfs:label "expression"@en;
+  rdfs:comment """Expression associated with the TripleExpression."""@en;
+  rdfs:domain shex:Shape;
+  rdfs:range shex:TripleExpression;
+  rdfs:isDefinedBy shex: .
+shex:extra a rdf:Property;
+  rdfs:label "extra"@en;
+  rdfs:comment """Properties which may have extra values beyond those matched through a constraint."""@en;
+  rdfs:domain shex:Shape;
+  rdfs:range rdfs:Resource;
+  rdfs:isDefinedBy shex: .
+shex:shapeExprs a rdf:Property;
+  rdfs:label "shape expressions"@en;
+  rdfs:comment """A list of 2 or more Shape Expressions referenced by this shape."""@en;
+  rdfs:subPropertyOf shex:shapeExpr;
+  rdfs:domain [ owl:unionOf (shex:ShapeAnd shex:ShapeOr)];
+  rdfs:range shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
+shex:shapeExpr a rdf:Property;
+  rdfs:label "shape expression"@en;
+  rdfs:comment """Shape Expression referenced by this shape."""@en;
+  rdfs:domain shex:ShapeNot;
+  rdfs:range shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
+shex:stem a rdf:Property;
+  rdfs:label "stem"@en;
+  rdfs:comment """A stem value used for matching or excluding values."""@en;
+  rdfs:domain [ owl:unionOf (shex:Stem shex:StemRange)];
+  rdfs:range [ owl:unionOf (xsd:anyUri shex:Wildcard)];
+  rdfs:isDefinedBy shex: .
+shex:exclusion a rdf:Property;
+  rdfs:label "exclusion"@en;
+  rdfs:comment """Values that are excluded from value matching."""@en;
+  rdfs:domain shex:StemRange;
+  rdfs:range [ owl:unionOf (rdfs:Resource shex:Stem)];
+  rdfs:isDefinedBy shex: .
+shex:inverse a rdf:Property;
+  rdfs:label "inverse"@en;
+  rdfs:comment """Constrains the subject of a triple, rather than the object."""@en;
+  rdfs:domain shex:TripleConstraint;
+  rdfs:range xsd:boolean;
+  rdfs:isDefinedBy shex: .
 shex:valueExpr a rdf:Property;
   rdfs:label "value expression"@en;
   rdfs:comment """A ShapeExpression used for matching the object (or subject if inverted) of a TripleConstraint."""@en;
   rdfs:domain shex:TripleConstraint;
   rdfs:range shex:ShapeExpression;
   rdfs:isDefinedBy shex: .
-shex:xsFacet a rdf:Property;
+shex:numericFacet a rdf:Property;
   rdfs:label ""@en;
-  rdfs:comment """An abstract property of string and numeric facets on a NodeConstraint."""@en;
-  rdfs:domain shex:NodeConstraint;
+  rdfs:comment """Abstract property of numeric facets on a NodeConstraint."""@en;
+  rdfs:subPropertyOf shex:xsFacet;
+  rdfs:isDefinedBy shex: .
+shex:stringFacet a rdf:Property;
+  rdfs:label ""@en;
+  rdfs:comment """An abstract property of string facets on a NodeConstraint."""@en;
+  rdfs:subPropertyOf shex:xsFacet;
   rdfs:isDefinedBy shex: .
 
 # Datatype definitions

--- a/ns/vocab.csv
+++ b/ns/vocab.csv
@@ -1,72 +1,70 @@
-id,type,label,subClassOf,domain,range,@type,@container,term,comment,
-,rdfs:seeAlso,,https://shexspec.github.io/spec,,,,,,,
-literal,NodeKind,literal,,,,,,,Requires node to be an rdf:Literal,
-nonliteral,NodeKind,nonliteral,,,,,,,Requires node to be a Blank Node or IRI,
-iri,NodeKind,iri,,,,,,,Requires node to be an IRI,
-bnode,NodeKind,bnode,,,,,,,Requires node to be a Blank Node,
-rdf,prefix,,http://www.w3.org/1999/02/22-rdf-syntax-ns#,,,,,,,
-rdfs,prefix,,http://www.w3.org/2000/01/rdf-schema#,,,,,,,
-shex,prefix,,http://shex.io/ns/shex#,,,,,,,
-xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,,,
-annotation,rdf:Property,annotation,,"EachOf,OneOf,TripleConstraint",Annotation,,,,Annotations on a TripleExpression.,
-closed,rdf:Property,closed,,Shape,xsd:boolean,,,,"Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints.",
-code,rdf:Property,code,,SemAct,xsd:string,,,,Code executed by Semantic Action.,
-datatype,rdf:Property,datatype,,NodeConstraint,rdfs:Datatype,,,,A datatype constraint.,
-exclusion,rdf:Property,exclusion,,StemRange,"rdfs:Resource,Stem",,,,Values that are excluded from value matching.,
-expression,rdf:Property,expression,,Shape,TripleExpression,,,,Expression associated with the TripleExpression.,
-expressions,rdf:Property,expressions,,"EachOf,OneOf",TripleExpression,,@list,,List of 2 or more expressions associated with the TripleExpression.,
-extra,rdf:Property,extra,,Shape,rdfs:Resource,,,,Properties which may have extra values beyond those matched through a constraint.,
-fractiondigits,rdf:Property,fraction digits,numericFacet,NodeConstraint,xsd:integer,,,,"for ""fractiondigits"" constraints, v is less than or equals the number of digits to the right of the decimal place in the XML Schema canonical form[xmlschema-2] of the value of n, ignoring trailing zeros.",
-inverse,rdf:Property,inverse,,TripleConstraint,xsd:boolean,,,,"Constrains the subject of a triple, rather than the object.",
-length,rdf:Property,length,stringFacet,NodeConstraint,xsd:integer,,,,The exact length of the value of the cell.,
-max,rdf:Property,maximum cardinality,,"EachOf,OneOf,TripleConstraint",,,,,Maximum number of times this TripleExpression may match.,
-maxexclusive,rdf:Property,max exclusive,numericFacet,NodeConstraint,"xsd:integer,xsd:decimal,xsd:double",,,,An atomic property that contains a single number that is the maximum valid value (exclusive).,
-maxinclusive,rdf:Property,max inclusive,numericFacet,NodeConstraint,"xsd:integer,xsd:decimal,xsd:double",,,,An atomic property that contains a single number that is the maximum valid value (inclusive).,
-maxlength,rdf:Property,max length,stringFacet,NodeConstraint,xsd:integer,,,,A numeric atomic property that contains a single integer that is the maximum length of the value.,
-min,rdf:Property,minimum cardinatliy,,"EachOf,OneOf,TripleConstraint",xsd:integer,,,,Minimum number of times this TripleExpression may match.,
-minexclusive,rdf:Property,min exclusive,numericFacet,NodeConstraint,"xsd:integer,xsd:decimal,xsd:double",,,,An atomic property that contains a single number that is the minimum valid value (exclusive).,
-mininclusive,rdf:Property,min inclusive,numericFacet,NodeConstraint,"xsd:integer,xsd:decimal,xsd:double",,,,An atomic property that contains a single number that is the minimum valid value (inclusive).,
-minlength,rdf:Property,min length,stringFacet,NodeConstraint,xsd:integer,,,,An atomic property that contains a single integer that is the minimum length of the value.,
-name,rdf:Property,name,,SemAct,rdfs:Resource,,,,Identifier of SemAct extension.,
-nodeKind,rdf:Property,node kind,,NodeConstraint,NodeKind,@vocab,,,"Restiction on the kind of node matched; restricted to the defined instances of NodeKind. One of shex:iri, shex:bnode, shex:literal, or shex:nonliteral.",
-numericFacet,rdf:Property,,xsFacet,,,,,,Abstract property of numeric facets on a NodeConstraint.,
-object,rdf:Property,object,,Annotation,rdfs:Resource,,,,The object of an Annotation.,
-pattern,rdf:Property,pattern,stringFacet,NodeConstraint,xsd:string,,,,A regular expression used for matching a value.,
-predicate,rdf:Property,predicate,,"Annotation,TripleConstraint",rdfs:Resource,,,,The predicate of a TripleConstraint or Annotation.,
-semActs,rdf:Property,semantic action,,"EachOf,OneOf,TripleConstraint",SemAct,,@list,,Semantic Actions on this TripleExpression.,
-shapes,rdf:Property,shapes,,Schema,ShapeExpression,,,,Shapes in this Schema.,
-shapeExpr,rdf:Property,shape expression,,ShapeNot,ShapeExpression,,,,Shape Expression referenced by this shape.,
-shapeExprs,rdf:Property,shape expressions,shapeExpr,"ShapeAnd,ShapeOr",ShapeExpression,,@list,,A list of 2 or more Shape Expressions referenced by this shape.,
-start,rdf:Property,start,,Schema,ShapeExpression,,,,A ShapeExpression matched against the focus node prior to any other mapped expressions.,
-startActs,rdf:Property,start actions,,Schema,SemAct,,@list,,Semantic Actions run on the Schema.,
-stem,rdf:Property,stem,,"Stem,StemRange","xsd:anyUri,Wildcard",,,,A stem value used for matching or excluding values.,
-stringFacet,rdf:Property,,xsFacet,,,,,,An abstract property of string facets on a NodeConstraint.,
-totaldigits,rdf:Property,total digits,numericFacet,NodeConstraint,xsd:integer,,,,"for ""totaldigits"" constraints, v equals the number of digits in the XML Schema canonical form[xmlschema-2] of the value of n",
-values,rdf:Property,values,,NodeConstraint,"rdfs:Resource,Stem,StemRange",,@list,,A value restriction on a NodeConstraint.,
-valueExpr,rdf:Property,value expression,,TripleConstraint,ShapeExpression,,,,A ShapeExpression used for matching the object (or subject if inverted) of a TripleConstraint.,
-xsFacet,rdf:Property,,,NodeConstraint,,,,,An abstract property of string and numeric facets on a NodeConstraint.,
-Annotation,rdfs:Class,Annotation,,,,,,,Annotations provide a format-independent way to provide additional information about elements in a schema. ,
-EachOf,rdfs:Class,Each Of,TripleExpression,,,,,,"A TripleExpression composed of one or more sub-expressions, all of which must match.",
-NodeConstraint,rdfs:Class,Node Constraint,ShapeExpression,,,,,,A constraint on the type or value of an RDF Node.,
-NodeKind,rdfs:Class,Node Kind,,,,,,,The set of kinds of RDF Nodes.,
-OneOf,rdfs:Class,One Of,TripleExpression,,,,,,"A TripleExpression composed of one or more sub-expressions, one of which must match.",
-Schema,rdfs:Class,Schema,,,,,,,"A Schema contains the set of shapes, used for matching a focus node.",
-SemAct,rdfs:Class,Semantic Actions,,,,,,,"A list of Semantic Actions that serve as an extension point for Shape Expressions. They appear in lists in Schema's startActs and Shape, OneOf, EachOf and TripleConstraint's semActs.",
-Shape,rdfs:Class,Shape Or,ShapeExpression,,,,,,A shapes schema is captured in a Schema object where shapes is a mapping from shape label to shape expression.,
-ShapeAnd,rdfs:Class,Shape And,ShapeExpression,,,,,,"A ShapeExpression composed of one or more sub-expressions, all of which must match.",
-ShapeExpression,rdfs:Class,Shape Expression,,,,,,,The abstract class of Shape Expressions.,
-ShapeExternal,rdfs:Class,Shape External,ShapeExpression,,,,,,A reference to a shape defined in some external Schema.,
-ShapeNot,rdfs:Class,Shape Not,ShapeExpression,,,,,,A ShapeNot is satisfied when it’s included ShapeExpression is not satisfied.,
-ShapeOr,rdfs:Class,Shape Or,ShapeExpression,,,,,,"A ShapeExpression composed of one or more sub-expressions, one of which must match.",
-Stem,rdfs:Class,Stem,,,,,,,An IRI prefix used for matching IRIs.,
-StemRange,rdfs:Class,StemRange,,,,,,,"An IRI prefix (or wildcard) along with a set of excluded values, used for node matching.",
-TripleConstraint,rdfs:Class,Triple Constraint,TripleExpression,,,,,,A constraint on a triple having a specific predicate and optionally a shape expression used for matching values.,
-TripleExpression,rdfs:Class,Triple Expression,,,,,,,The abstract class of Triple Expressions.,
-Wildcard,rdfs:Class,Wildcard,,,,,,,"Indicates that a stem is a Wildcard, rather than a URI prefix.",
-annotations,term,,annotation,,,@id,,,A synonym for the annotation property.,
-exclusions,term,,exclusion,,,@id,,,A synonym for the exclusion property.,
-id,term,,@id,,,,,,A synonym for @id.,
-language,term,,@language,,,,,,A synonym for @language.,
-type,term,,@type,,,,,,A synonym for @type.,
-uri,term,,@id,,,,,,A synonym for @id.,
-value,term,,@value,,,,,,A synonym for @value.,
+id,type,label,subClassOf,domain,range,@type,@container,ForwardMultiplicity,ReverseMultiplicity,term,comment
+,rdfs:seeAlso,,https://shexspec.github.io/spec,,,,,,,,
+literal,NodeKind,literal,,,,,,,,,Requires node to be an rdf:Literal
+nonliteral,NodeKind,nonliteral,,,,,,,,,Requires node to be a Blank Node or IRI
+iri,NodeKind,iri,,,,,,,,,Requires node to be an IRI
+bnode,NodeKind,bnode,,,,,,,,,Requires node to be a Blank Node
+rdf,prefix,,http://www.w3.org/1999/02/22-rdf-syntax-ns#,,,,,,,,
+rdfs,prefix,,http://www.w3.org/2000/01/rdf-schema#,,,,,,,,
+shex,prefix,,http://shex.io/ns/shex#,,,,,,,,
+xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,,,,
+object,rdf:Property,object,,Annotation,rdfs:Resource,,,1:1,0:N,,The object of an Annotation.
+predicate,rdf:Property,predicate,,"Annotation,TripleConstraint",rdfs:Resource,,,1:1,0:N,,The predicate of a TripleConstraint or Annotation.
+expressions,rdf:Property,expressions,,"EachOf,OneOf",TripleExpression,,@list,1:N,0:N,,List of 2 or more expressions associated with the TripleExpression.
+annotation,rdf:Property,annotation,,"EachOf,OneOf,TripleConstraint",Annotation,,,0:N,1:N,,Annotations on a TripleExpression.
+max,rdf:Property,maximum cardinality,,"EachOf,OneOf,TripleConstraint",xsd:integer,,,1:1,,,Maximum number of times this TripleExpression may match.
+min,rdf:Property,minimum cardinatliy,,"EachOf,OneOf,TripleConstraint",xsd:integer,,,1:1,,,Minimum number of times this TripleExpression may match.
+semActs,rdf:Property,semantic action,,"EachOf,OneOf,TripleConstraint",SemAct,,@list,0:N,1:N,,Semantic Actions on this TripleExpression.
+datatype,rdf:Property,datatype,,NodeConstraint,xsd:Datatype,,,0:1,0:N,,A datatype constraint.
+fractiondigits,rdf:Property,fraction digits,numericFacet,NodeConstraint,xsd:integer,,,0:1,,,"for ""fractiondigits"" constraints, v is less than or equals the number of digits to the right of the decimal place in the XML Schema canonical form[xmlschema-2] of the value of n, ignoring trailing zeros."
+length,rdf:Property,length,stringFacet,NodeConstraint,xsd:integer,,,0:1,,,The exact length of the value of the cell.
+maxexclusive,rdf:Property,max exclusive,numericFacet,NodeConstraint,"xsd:integer,xsd:decimal,xsd:double",,,0:1,,,An atomic property that contains a single number that is the maximum valid value (exclusive).
+maxinclusive,rdf:Property,max inclusive,numericFacet,NodeConstraint,"xsd:integer,xsd:decimal,xsd:double",,,0:1,,,An atomic property that contains a single number that is the minimum valid value (inclusive).
+maxlength,rdf:Property,max length,stringFacet,NodeConstraint,xsd:integer,,,0:1,,,A numeric atomic property that contains a single integer that is the maximum length of the value.
+minlength,rdf:Property,min length,stringFacet,NodeConstraint,xsd:integer,,,0:1,,,An atomic property that contains a single integer that is the minimum length of the value.
+nodeKind,rdf:Property,node kind,,NodeConstraint,NodeKind,@vocab,,0:1,,,"Restiction on the kind of node matched; restricted to the defined instances of NodeKind. One of shex:iri, shex:bnode, shex:literal, or shex:nonliteral."
+pattern,rdf:Property,pattern,stringFacet,NodeConstraint,xsd:string,,,0:1,,,A regular expression used for matching a value.
+totaldigits,rdf:Property,total digits,numericFacet,NodeConstraint,xsd:integer,,,0:1,,,"for ""totaldigits"" constraints, v equals the number of digits in the XML Schema canonical form[xmlschema-2] of the value of n"
+values,rdf:Property,values,,NodeConstraint,"rdfs:Resource,Stem,StemRange",,@list,0:N,0:N,,A value restriction on a NodeConstraint.
+xsFacet,rdf:Property,,,NodeConstraint,,,,,,,An abstract property of string and numeric facets on a NodeConstraint.
+shapes,rdf:Property,shapes,,Schema,ShapeExpression,,,0:1,1:1,,Shapes in this Schema.
+start,rdf:Property,start,,Schema,ShapeExpression,,,0:1,0:1,,A ShapeExpression matched against the focus node prior to any other mapped expressions.
+startActs,rdf:Property,start actions,,Schema,SemAct,,@list,0:N,,,Semantic Actions run on the Schema.
+code,rdf:Property,code,,SemAct,xsd:string,,,1:1,,,Code executed by Semantic Action.
+name,rdf:Property,name,,SemAct,rdfs:Resource,,,1:1,0:N,,Identifier of SemAct extension.
+closed,rdf:Property,closed,,Shape,xsd:boolean,,,0:1,,,"Indicates that a Shape is closed, meaning that it may contain no property values other than those used within TripleConstraints."
+expression,rdf:Property,expression,,Shape,TripleExpression,,,0:N,0:N,,Expression associated with the TripleExpression.
+extra,rdf:Property,extra,,Shape,rdfs:Resource,,,0:N,0:N,,Properties which may have extra values beyond those matched through a constraint.
+shapeExprs,rdf:Property,shape expressions,shapeExpr,"ShapeAnd,ShapeOr",ShapeExpression,,@list,1:N,0:N,,A list of 2 or more Shape Expressions referenced by this shape.
+shapeExpr,rdf:Property,shape expression,,ShapeNot,ShapeExpression,,,1:1,0:N,,Shape Expression referenced by this shape.
+stem,rdf:Property,stem,,"Stem,StemRange","xsd:anyUri,Wildcard",,,1:1,0:N,,A stem value used for matching or excluding values.
+exclusion,rdf:Property,exclusion,,StemRange,"rdfs:Resource,Stem",,,0:N,0:N,,Values that are excluded from value matching.
+inverse,rdf:Property,inverse,,TripleConstraint,xsd:boolean,,,0:1,,,"Constrains the subject of a triple, rather than the object."
+valueExpr,rdf:Property,value expression,,TripleConstraint,ShapeExpression,,,1:1,0:N,,A ShapeExpression used for matching the object (or subject if inverted) of a TripleConstraint.
+numericFacet,rdf:Property,,xsFacet,,,,,,,,Abstract property of numeric facets on a NodeConstraint.
+stringFacet,rdf:Property,,xsFacet,,,,,,,,An abstract property of string facets on a NodeConstraint.
+Annotation,rdfs:Class,Annotation,,,,,,,,,Annotations provide a format-independent way to provide additional information about elements in a schema. 
+EachOf,rdfs:Class,Each Of,TripleExpression,,,,,,,,"A TripleExpression composed of one or more sub-expressions, all of which must match."
+NodeConstraint,rdfs:Class,Node Constraint,ShapeExpression,,,,,,,,A constraint on the type or value of an RDF Node.
+NodeKind,rdfs:Class,Node Kind,,,,,,,,,The set of kinds of RDF Nodes.
+OneOf,rdfs:Class,One Of,TripleExpression,,,,,,,,"A TripleExpression composed of one or more sub-expressions, one of which must match."
+Schema,rdfs:Class,Schema,,,,,,,,,"A Schema contains the set of shapes, used for matching a focus node."
+SemAct,rdfs:Class,Semantic Actions,,,,,,,,,"A list of Semantic Actions that serve as an extension point for Shape Expressions. They appear in lists in Schema's startActs and Shape, OneOf, EachOf and TripleConstraint's semActs."
+Shape,rdfs:Class,Shape Or,ShapeExpression,,,,,,,,A shapes schema is captured in a Schema object where shapes is a mapping from shape label to shape expression.
+ShapeAnd,rdfs:Class,Shape And,ShapeExpression,,,,,,,,"A ShapeExpression composed of one or more sub-expressions, all of which must match."
+ShapeExpression,rdfs:Class,Shape Expression,,,,,,,,,The abstract class of Shape Expressions.
+ShapeExternal,rdfs:Class,Shape External,ShapeExpression,,,,,,,,A reference to a shape defined in some external Schema.
+ShapeNot,rdfs:Class,Shape Not,ShapeExpression,,,,,,,,A ShapeNot is satisfied when it’s included ShapeExpression is not satisfied.
+ShapeOr,rdfs:Class,Shape Or,ShapeExpression,,,,,,,,"A ShapeExpression composed of one or more sub-expressions, one of which must match."
+Stem,rdfs:Class,Stem,,,,,,,,,An IRI prefix used for matching IRIs.
+StemRange,rdfs:Class,StemRange,,,,,,,,,"An IRI prefix (or wildcard) along with a set of excluded values, used for node matching."
+TripleConstraint,rdfs:Class,Triple Constraint,TripleExpression,,,,,,,,A constraint on a triple having a specific predicate and optionally a shape expression used for matching values.
+TripleExpression,rdfs:Class,Triple Expression,,,,,,,,,The abstract class of Triple Expressions.
+Wildcard,rdfs:Class,Wildcard,,,,,,,,,"Indicates that a stem is a Wildcard, rather than a URI prefix."
+annotations,term,,annotation,,,@id,,,,,A synonym for the annotation property.
+exclusions,term,,exclusion,,,@id,,,,,A synonym for the exclusion property.
+id,term,,@id,,,,,,,,A synonym for @id.
+language,term,,@language,,,,,,,,A synonym for @language.
+type,term,,@type,,,,,,,,A synonym for @type.
+uri,term,,@id,,,,,,,,A synonym for @id.
+value,term,,@value,,,,,,,,A synonym for @value.


### PR DESCRIPTION
I added stuff so that we also have definition of the shex json-ld in shexc. shex.shexc not complete but its a initial setup. We need to add a test in which we go from vocab.csv -> ShExC -> ShexJSONLD -> and then validate it using its own definition. And a second test that does ShexJSONLD -> ShExC ->ShexJSONLD -> ShExC and validates that conversion back and forward is working and conserving all information.

added initial version of the shex.shexc generator
added forward and reverse multiplicity columns
fixed few records in vocab.csv
-Removed duplicated maxexclusive and minexclusive properties
-Changed rdfs:Datetype to xsd:Datetype
-Reordered the properties on domain
added install.sh script for installing needed dependencies